### PR TITLE
added sync between textarea and tinymce-rte

### DIFF
--- a/assets/components/tinymcerte/js/mgr/tinymcerte.js
+++ b/assets/components/tinymcerte/js/mgr/tinymcerte.js
@@ -29,6 +29,9 @@ Ext.extend(TinyMCERTE.Tiny,Ext.Component,{
         this.cfg.file_browser_callback = this.loadBrowser;
         this.cfg.init_instance_callback = function(editor) {
             that.editor = editor;
+            editor.on('change', function () {   // Keep synced textarea and iframe on each change
+                tinymce.triggerSave();
+            });
             var saveKey = MODx.config.keymap_save || 's';
             editor.addShortcut('ctrl+' + saveKey, '', function () {
                 var btn = Ext.getCmp('modx-abtn-save');


### PR DESCRIPTION
This commit try to fix #17, in fact resolve the issues mentioned by @Mark-H the unsync with the underlying textarea.
I tested the fix for ContentBlock and is working on my local install.

Maybe the problem is linked with the ability of TinyMCE 4> to manage multiple textare with a unique instance.
Thx to the author of  http://jsfiddle.net/9euk9/ that give the idea.